### PR TITLE
Fix shading

### DIFF
--- a/MiniGamesBox Classic/pom.xml
+++ b/MiniGamesBox Classic/pom.xml
@@ -79,6 +79,7 @@
             <artifactId>scoreboard</artifactId>
             <version>1.0.9</version>
             <scope>compile</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>com.github.cryptomorin</groupId>
@@ -128,6 +129,7 @@
             <artifactId>MiniGamesBox-Inventory</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>me.clip</groupId>

--- a/MiniGamesBox Classic/pom.xml
+++ b/MiniGamesBox Classic/pom.xml
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>com.github.cryptomorin</groupId>
             <artifactId>XSeries</artifactId>
-            <version>8.5.0.1</version>
+            <version>8.6.0</version>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/handlers/powerup/PowerupRegistry.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/handlers/powerup/PowerupRegistry.java
@@ -110,11 +110,11 @@ public class PowerupRegistry {
         if(pickup.getPowerup().getPotionType() == BasePowerup.PotionType.ALL) {
           for(Player p : pickup.getArena().getPlayers()) {
             VersionUtils.sendTitles(p, pickup.getPowerup().getName(), pickup.getPowerup().getDescription(), 5, 30, 5);
-            XPotion.addPotionEffectsFromString(p, pickup.getPowerup().getEffects());
+            XPotion.addEffects(p, pickup.getPowerup().getEffects());
           }
         } else {
           VersionUtils.sendTitles(pickup.getPlayer(), pickup.getPowerup().getName(), pickup.getPowerup().getDescription(), 5, 30, 5);
-          XPotion.addPotionEffectsFromString(pickup.getPlayer(), pickup.getPowerup().getEffects());
+          XPotion.addEffects(pickup.getPlayer(), pickup.getPowerup().getEffects());
         }
         int duration = getLongestEffect(pickup.getPowerup());
 


### PR DESCRIPTION
Avoid Inventory being explicitly included in Classic. Fix a shading issue on Village Defense.