### PR TITLE
Optimize replace process in MessageBuilder

### DIFF
--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/handlers/language/MessageBuilder.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/handlers/language/MessageBuilder.java
@@ -228,8 +228,9 @@ public class MessageBuilder {
 
     StringBuilder builder = new StringBuilder(text);
     int searchLength = search.length();
+    int replacementLength = replacement.get().length();
 
-    while ((index = builder.replace(index, index + searchLength, replacement.get()).indexOf(search)) != -1) {
+    while ((index = builder.replace(index, index + searchLength, replacement.get()).indexOf(search, index += replacementLength)) != -1) {
     }
 
     return builder.toString();

--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/handlers/language/MessageBuilder.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/handlers/language/MessageBuilder.java
@@ -21,8 +21,6 @@ package plugily.projects.minigamesbox.classic.handlers.language;
 
 import me.clip.placeholderapi.PlaceholderAPI;
 
-import java.util.List;
-
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
@@ -207,22 +205,19 @@ public class MessageBuilder {
   }
 
   private void formatArena() {
-    final int timer = arena.getTimer();
-    final List<Player> playersLeft = arena.getPlayersLeft();
-
     message = replace(message, "%arena_min_players%", () -> placeholderColorOther + arena.getMinimumPlayers() + messageColor);
     message = replace(message, "%arena_players%", () -> placeholderColorOther + arena.getPlayers() + messageColor);
     message = replace(message, "%arena_players_size%", () -> placeholderColorOther + arena.getPlayers().size() + messageColor);
-    message = replace(message, "%arena_players_left%", () -> placeholderColorOther + playersLeft + messageColor);
-    message = replace(message, "%arena_players_left_size%", () -> placeholderColorOther + playersLeft.size() + messageColor);
+    message = replace(message, "%arena_players_left%", () -> placeholderColorOther + arena.getPlayersLeft() + messageColor);
+    message = replace(message, "%arena_players_left_size%", () -> placeholderColorOther + arena.getPlayersLeft().size() + messageColor);
     message = replace(message, "%arena_max_players%", () -> placeholderColorOther + arena.getMaximumPlayers() + messageColor);
     message = replace(message, "%arena_name%", () -> placeholderColorOther + arena.getMapName() + messageColor);
     message = replace(message, "%arena_id%", () -> placeholderColorOther + arena.getId() + messageColor);
     message = replace(message, "%arena_state%", () -> placeholderColorOther + arena.getArenaState() + messageColor);
     message = replace(message, "%arena_state_formatted%", () -> placeholderColorOther + arena.getArenaState().getFormattedName() + messageColor);
     message = replace(message, "%arena_state_placeholder%", () -> placeholderColorOther + arena.getArenaState().getPlaceholder() + messageColor);
-    message = replace(message, "%arena_time%", () -> placeholderColorOther + timer + messageColor);
-    message = replace(message, "%arena_time_formatted%", () -> placeholderColorOther + StringFormatUtils.formatIntoMMSS(timer) + messageColor);
+    message = replace(message, "%arena_time%", () -> placeholderColorOther + arena.getTimer() + messageColor);
+    message = replace(message, "%arena_time_formatted%", () -> placeholderColorOther + StringFormatUtils.formatIntoMMSS(arena.getTimer()) + messageColor);
   }
 
   private String replace(String text, String search, java.util.function.Supplier<String> replacement) {

--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/handlers/language/MessageBuilder.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/handlers/language/MessageBuilder.java
@@ -20,7 +20,6 @@
 package plugily.projects.minigamesbox.classic.handlers.language;
 
 import me.clip.placeholderapi.PlaceholderAPI;
-
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
@@ -265,13 +264,6 @@ public class MessageBuilder {
     build();
     if(message != null && !message.isEmpty()) {
       commandSender.sendMessage(message);
-    }
-  }
-
-  public void send(Player player) {
-    build();
-    if(message != null && !message.isEmpty()) {
-      player.sendMessage(message);
     }
   }
 


### PR DESCRIPTION
The implemented `replace` method is much faster than Apache replace method as it only contains 3 parameters and fewer checks which much better. It is pretty useless to use Apache methods in here especially if doesn't have any maximum specified for how many strings are allowed to replace in a string. Also the `Supplier` function used to minimize the amount of called methods if the specified `search` string can not be found in string, ie the user did not added this placeholder to scoreboard for example.