### PR TITLE
Avoid using streams where possible

### DIFF
--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/PluginMain.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/PluginMain.java
@@ -86,7 +86,6 @@ import plugily.projects.minigamesbox.classic.utils.version.events.EventsInitiali
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Random;
 import java.util.logging.Level;
 
@@ -306,9 +305,8 @@ public class PluginMain extends JavaPlugin {
   }
 
   public void setupFiles() {
-    for(String fileName : getFileNames()) {
-      File file = new File(getDataFolder(), fileName + ".yml");
-      if(!file.exists()) {
+    for(String fileName : fileNames) {
+      if(!new File(getDataFolder(), fileName + ".yml").exists()) {
         saveResource(fileName + ".yml", false);
       }
     }
@@ -364,13 +362,10 @@ public class PluginMain extends JavaPlugin {
     long start = System.currentTimeMillis();
 
     Bukkit.getLogger().removeHandler(getExceptionLogHandler());
-    if(getArenaRegistry() != null) {
-      for(PluginArena arena : getArenaRegistry().getArenas()) {
-        List<Player> arenaPlayers = new ArrayList<>(arena.getPlayers());
-        if(!arenaPlayers.isEmpty()) {
-          for(Player player : arenaPlayers) {
-            getArenaManager().leaveAttempt(player, arena);
-          }
+    if(arenaRegistry != null) {
+      for(PluginArena arena : arenaRegistry.getArenas()) {
+        for(Player player : new ArrayList<>(arena.getPlayers())) {
+          arenaManager.leaveAttempt(player, arena);
         }
         arena.getMapRestorerManager().fullyRestoreArena();
       }

--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/api/StatsStorage.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/api/StatsStorage.java
@@ -22,7 +22,6 @@ import org.bukkit.entity.Player;
 import plugily.projects.minigamesbox.classic.PluginMain;
 import plugily.projects.minigamesbox.classic.arena.PluginArena;
 import plugily.projects.minigamesbox.classic.handlers.placeholder.Placeholder;
-import plugily.projects.minigamesbox.classic.user.User;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -89,8 +88,7 @@ public class StatsStorage {
    * @see StatisticType
    */
   public int getUserStats(Player player, StatisticType statisticType) {
-    User user = plugin.getUserManager().getUser(player);
-    return user.getStatistic(statisticType);
+    return plugin.getUserManager().getUser(player).getStatistic(statisticType);
   }
 
 
@@ -101,10 +99,13 @@ public class StatsStorage {
    * @return true or false based on user configuration
    */
   public String getStatisticName(String key) {
-    if(!statistics.containsKey(key)) {
+    StatisticType statisticType = statistics.get(key);
+
+    if(statisticType == null) {
       throw new IllegalStateException("Statistic with key " + key + " does not exist");
     }
-    return statistics.get(key).getName();
+
+    return statisticType.getName();
   }
 
 
@@ -115,10 +116,13 @@ public class StatsStorage {
    * @return true or false based on user configuration
    */
   public StatisticType getStatisticType(String key) {
-    if(!statistics.containsKey(key)) {
+    StatisticType statisticType = statistics.get(key);
+
+    if(statisticType == null) {
       throw new IllegalStateException("Statistic with key " + key + " does not exist");
     }
-    return statistics.get(key);
+
+    return statisticType;
   }
 
   /**

--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/arena/PluginArena.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/arena/PluginArena.java
@@ -43,13 +43,13 @@ import plugily.projects.minigamesbox.classic.user.User;
 import plugily.projects.minigamesbox.classic.utils.configuration.ConfigUtils;
 import plugily.projects.minigamesbox.classic.utils.version.VersionUtils;
 
+import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * @author Tigerpanzer_02
@@ -115,24 +115,33 @@ public class PluginArena extends BukkitRunnable {
    * @return true or false based on user configuration
    */
   public Integer getArenaOption(String name) {
-    if(!arenaOptions.containsKey(name)) {
+    ArenaOption arenaOption = arenaOptions.get(name);
+
+    if(arenaOption == null) {
       throw new IllegalStateException("Option with name " + name + " does not exist");
     }
-    return arenaOptions.get(name).getValue();
+
+    return arenaOption.getValue();
   }
 
   public void setArenaOption(String name, int value) {
-    if(!arenaOptions.containsKey(name)) {
+    ArenaOption arenaOption = arenaOptions.get(name);
+
+    if(arenaOption == null) {
       throw new IllegalStateException("Option with name " + name + " does not exist");
     }
-    arenaOptions.get(name).setValue(value);
+
+    arenaOption.setValue(value);
   }
 
   public void changeArenaOptionBy(String name, int value) {
-    if(!arenaOptions.containsKey(name)) {
+    ArenaOption arenaOption = arenaOptions.get(name);
+
+    if(arenaOption == null) {
       throw new IllegalStateException("Option with name " + name + " does not exist");
     }
-    arenaOptions.get(name).setValue(arenaOptions.get(name).getValue() + value);
+
+    arenaOption.setValue(arenaOption.getValue() + value);
   }
 
 
@@ -172,8 +181,11 @@ public class PluginArena extends BukkitRunnable {
 
   private void setDefaultValues() {
     loadArenaOptions();
+
+    Location firstWorldSpawn = Bukkit.getWorlds().get(0).getSpawnLocation();
+
     for(GameLocation location : GameLocation.values()) {
-      gameLocations.put(location, Bukkit.getWorlds().get(0).getSpawnLocation());
+      gameLocations.put(location, firstWorldSpawn);
     }
   }
 
@@ -440,7 +452,15 @@ public class PluginArena extends BukkitRunnable {
 
   @NotNull
   public List<Player> getPlayersLeft() {
-    return plugin.getUserManager().getUsers(this).stream().filter(user -> !user.isSpectator()).map(User::getPlayer).collect(Collectors.toList());
+    List<Player> playersLeft = new ArrayList<>();
+
+    for (User user : plugin.getUserManager().getUsers(this)) {
+      if (!user.isSpectator()) {
+        playersLeft.add(user.getPlayer());
+      }
+    }
+
+    return playersLeft;
   }
 
   public PluginMain getPlugin() {

--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/arena/PluginArenaManager.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/arena/PluginArenaManager.java
@@ -36,8 +36,6 @@ import plugily.projects.minigamesbox.classic.utils.misc.MiscUtils;
 import plugily.projects.minigamesbox.classic.utils.misc.complement.ComplementAccessor;
 import plugily.projects.minigamesbox.classic.utils.version.VersionUtils;
 
-import java.util.List;
-
 /**
  * @author Tigerpanzer_02
  * <p>
@@ -73,7 +71,6 @@ public class PluginArenaManager {
     }
 
     arena.getPlayers().add(player);
-    User user = plugin.getUserManager().getUser(player);
 
     if(arena.getArenaState() == ArenaState.IN_GAME || arena.getArenaState().isStartingStage(arena) && arena.getTimer() <= 3 || arena.getArenaState() == ArenaState.ENDING) {
       if(!plugin.getConfigPreferences().getOption("SPECTATORS")) {
@@ -101,7 +98,7 @@ public class PluginArenaManager {
 
     new MessageBuilder(MessageBuilder.ActionType.JOIN).arena(arena).player(player).sendArena();
 
-    user.setKit(plugin.getKitRegistry().getDefaultKit());
+    plugin.getUserManager().getUser(player).setKit(plugin.getKitRegistry().getDefaultKit());
     plugin.getSpecialItemManager().addSpecialItemsOfStage(player, SpecialItem.DisplayStage.LOBBY);
     if(arena.getArenaState() == ArenaState.WAITING_FOR_PLAYERS) {
       plugin.getSpecialItemManager().addSpecialItemsOfStage(player, SpecialItem.DisplayStage.WAITING_FOR_PLAYERS);
@@ -264,11 +261,10 @@ public class PluginArenaManager {
 
     Bukkit.getPluginManager().callEvent(new PlugilyGameStopEvent(arena));
     for(Player player : arena.getPlayers()) {
-      User user = plugin.getUserManager().getUser(player);
       if(!quickStop) {
         spawnFireworks(arena, player);
-        List<String> summaryMessages = plugin.getLanguageManager().getLanguageList("In-Game.Messages.Game-End.Summary");
-        for(String msg : summaryMessages) {
+
+        for(String msg : plugin.getLanguageManager().getLanguageList("In-Game.Messages.Game-End.Summary")) {
           MiscUtils.sendCenteredMessage(player, new MessageBuilder(msg).arena(arena).player(player).build());
         }
       }

--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/arena/PluginArenaRegistry.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/arena/PluginArenaRegistry.java
@@ -228,20 +228,21 @@ public class PluginArenaRegistry {
     arena.setMaximumPlayers(section.getInt(id + ".maximumplayers", 16));
     arena.setMapName(section.getString(id + ".mapname", id));
 
-    Location startLoc = LocationSerializer.getLocation(section.getString(id + ".startlocation"));
-    Location lobbyLoc = LocationSerializer.getLocation(section.getString(id + ".lobbylocation"));
-    Location endLoc = LocationSerializer.getLocation(section.getString(id + ".endlocation"));
-    Location spectatorLoc = LocationSerializer.getLocation(section.getString(id + ".spectatorlocation"));
+    Location startLoc = LocationSerializer.getLocation(section.getString(id + ".startlocation", null));
+    Location lobbyLoc = LocationSerializer.getLocation(section.getString(id + ".lobbylocation", null));
+    Location endLoc = LocationSerializer.getLocation(section.getString(id + ".endlocation", null));
+    Location spectatorLoc = LocationSerializer.getLocation(section.getString(id + ".spectatorlocation", null));
 
     if(lobbyLoc == null || startLoc == null || endLoc == null || spectatorLoc == null) {
       plugin.getDebugger().sendConsoleMsg(new MessageBuilder("VALIDATOR_INVALID_ARENA_CONFIGURATION").asKey().value("LOCATIONS ARE INVALID").arena(arena).build());
       return false;
     }
 
-    if(!section.getBoolean(id + ".isdone")) {
+    if(!section.getBoolean(id + ".isdone", false)) {
       plugin.getDebugger().sendConsoleMsg(new MessageBuilder("VALIDATOR_INVALID_ARENA_CONFIGURATION").asKey().value("NOT VALIDATED").arena(arena).build());
       return false;
     }
+
     arena.setLobbyLocation(lobbyLoc);
     arena.setStartLocation(startLoc);
     arena.setEndLocation(endLoc);

--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/arena/PluginArenaUtils.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/arena/PluginArenaUtils.java
@@ -191,8 +191,9 @@ public class PluginArenaUtils {
   }
 
   public static boolean areInSameArena(Player one, Player two) {
-    return plugin.getArenaRegistry().getArena(one) != null
-        && plugin.getArenaRegistry().getArena(one).equals(plugin.getArenaRegistry().getArena(two));
+    PluginArena arena = plugin.getArenaRegistry().getArena(one);
+
+    return arena != null && arena.equals(plugin.getArenaRegistry().getArena(two));
   }
 
   public static PluginMain getPlugin() {

--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/arena/managers/BossbarManager.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/arena/managers/BossbarManager.java
@@ -73,17 +73,15 @@ public class BossbarManager {
     if(gameBar == null) {
       return;
     }
-    List<String> values;
-    if(arena.getArenaState() == ArenaState.FULL_GAME) {
-      values = new ArrayList<>(bossbar.get(ArenaState.STARTING));
-    } else {
-      values = new ArrayList<>(bossbar.get(arena.getArenaState()));
-    }
-    int lines = values.size() - 1;
-    if(currentLine > lines) {
+
+    List<String> values = new ArrayList<>(bossbar.get(arena.getArenaState() == ArenaState.FULL_GAME ? ArenaState.STARTING : arena.getArenaState()));
+
+    if(currentLine > values.size() - 1) {
       currentLine = 0;
     }
+
     String bossbarMessage = new MessageBuilder(values.get(currentLine)).arena(arena).build();
+
     if(arena.getArenaOption("BAR_TOGGLE_VALUE") > interval) {
       currentLine++;
       arena.setArenaOption("BAR_TOGGLE_VALUE", 0);

--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/arena/managers/PluginScoreboardManager.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/arena/managers/PluginScoreboardManager.java
@@ -105,15 +105,12 @@ public class PluginScoreboardManager {
 
   public List<Entry> formatScoreboard(User user) {
     EntryBuilder builder = new EntryBuilder();
-    List<String> lines;
-    if(arena.getArenaState() == ArenaState.FULL_GAME) {
-      lines = plugin.getLanguageManager().getLanguageList("Scoreboard.Content.Waiting");
-    } else {
-      lines = plugin.getLanguageManager().getLanguageList("Scoreboard.Content." + arena.getArenaState().getFormattedName());
-    }
-    for(String line : lines) {
+
+    for(String line : plugin.getLanguageManager().getLanguageList(arena.getArenaState() == ArenaState.FULL_GAME ? "Scoreboard.Content.Waiting"
+        : "Scoreboard.Content." + arena.getArenaState().getFormattedName())) {
       builder.next(new MessageBuilder(line).player(user.getPlayer()).arena(arena).build());
     }
+
     return builder.build();
   }
 

--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/arena/states/PluginEndingState.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/arena/states/PluginEndingState.java
@@ -47,9 +47,7 @@ public class PluginEndingState implements ArenaStateHandler {
     setArenaTimer(-999);
     plugin.getDebugger().debug("START Arena {0} Running state {1} value for state {2} and time {3}", arena.getId(), ArenaState.ENDING, arenaState, arenaTimer);
 
-    int timer = arena.getTimer();
-
-    if(timer <= 0) {
+    if(arena.getTimer() <= 0) {
       for(Player player : arena.getPlayers()) {
         plugin.getRewardsHandler().performReward(player, arena, plugin.getRewardsHandler().getRewardType("END_GAME"));
       }

--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/arena/states/PluginRestartingState.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/arena/states/PluginRestartingState.java
@@ -50,9 +50,8 @@ public class PluginRestartingState implements ArenaStateHandler {
     setArenaState(ArenaState.RESTARTING);
     setArenaTimer(-999);
     plugin.getDebugger().debug("START Arena {0} Running state {1} value for state {2} and time {3}", arena.getId(), ArenaState.RESTARTING, arenaState, arenaTimer);
-    int timer = arena.getTimer();
 
-    if(timer <= 0) {
+    if(arena.getTimer() <= 0) {
       arena.getScoreboardManager().stopAllScoreboards();
       for(Player player : arena.getPlayers()) {
         PluginArenaUtils.resetPlayerAfterGame(player);

--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/arena/states/PluginStartingState.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/arena/states/PluginStartingState.java
@@ -116,12 +116,17 @@ public class PluginStartingState implements ArenaStateHandler {
     if(arena.isForceStart()) {
       arena.setForceStart(false);
     }
-    int shorter = plugin.getConfig().getInt("Time-Manager.Shorten-Waiting-Full", 15);
-    if(arena.getMaximumPlayers() == arena.getPlayers().size() && arena.getTimer() > shorter) {
-      arenaTimer = shorter;
-      arenaState = ArenaState.FULL_GAME;
-      new MessageBuilder("IN_GAME_MESSAGES_LOBBY_MAX_PLAYERS").asKey().arena(arena).sendArena();
+
+    if (arena.getMaximumPlayers() == arena.getPlayers().size()) {
+      int shorter = plugin.getConfig().getInt("Time-Manager.Shorten-Waiting-Full", 15);
+
+      if(arena.getTimer() > shorter) {
+        arenaTimer = shorter;
+        arenaState = ArenaState.FULL_GAME;
+        new MessageBuilder("IN_GAME_MESSAGES_LOBBY_MAX_PLAYERS").asKey().arena(arena).sendArena();
+      }
     }
+
     plugin.getDebugger().debug("END 2 Arena {0} Running state {1} value for state {2} and time {3}", arena.getId(), ArenaState.STARTING, arenaState, arenaTimer);
 
   }

--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/arena/states/PluginWaitingState.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/arena/states/PluginWaitingState.java
@@ -50,10 +50,9 @@ public class PluginWaitingState implements ArenaStateHandler {
     plugin.getDebugger().debug("START Arena {0} Running state {1} value for state {2} and time {3}", arena.getId(), ArenaState.WAITING_FOR_PLAYERS, arenaState, arenaTimer);
 
     int minPlayers = arena.getMinimumPlayers();
-    int timer = arena.getTimer();
 
     if(arena.getPlayers().size() < minPlayers) {
-      if(timer <= 0) {
+      if(arena.getTimer() <= 0) {
         arenaTimer = plugin.getConfig().getInt("Time-Manager.Waiting", 20);
         new MessageBuilder("IN_GAME_MESSAGES_LOBBY_WAITING_FOR_PLAYERS").asKey().integer(minPlayers).arena(arena).sendArena();
       }

--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/commands/arguments/game/CreateArgument.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/commands/arguments/game/CreateArgument.java
@@ -37,10 +37,7 @@ import plugily.projects.minigamesbox.classic.utils.configuration.ConfigUtils;
  */
 public class CreateArgument {
 
-  private final PluginArgumentsRegistry registry;
-
   public CreateArgument(PluginArgumentsRegistry registry) {
-    this.registry = registry;
     registry.mapArgument(registry.getPlugin().getPluginNamePrefixLong(), new LabeledCommandArgument("create", registry.getPlugin().getPluginNamePrefixLong() + ".admin.setup", CommandArgument.ExecutorType.PLAYER,
         new LabelData("/" + registry.getPlugin().getPluginNamePrefix() + " create &6<arena>", "/" + registry.getPlugin().getPluginNamePrefix() + " create <arena>",
             "&7Create new arena\n&6Permission: &7" + registry.getPlugin().getPluginNamePrefixLong() + ".admin.setup")) {

--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/commands/arguments/game/SetupArgument.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/commands/arguments/game/SetupArgument.java
@@ -38,10 +38,7 @@ import plugily.projects.minigamesbox.classic.utils.configuration.ConfigUtils;
  */
 public class SetupArgument {
 
-  private final PluginArgumentsRegistry registry;
-
   public SetupArgument(PluginArgumentsRegistry registry) {
-    this.registry = registry;
     registry.mapArgument(registry.getPlugin().getCommandAdminPrefixLong(), new LabeledCommandArgument("setup", registry.getPlugin().getCommandAdminPrefixLong() + ".admin.setup", CommandArgument.ExecutorType.PLAYER,
         new LabelData("/" + registry.getPlugin().getCommandAdminPrefix() + " setup &c[create/edit] &c[arena]", "/" + registry.getPlugin().getCommandAdminPrefixLong() + " setup [create/edit] [arena]",
             "&7Used for all setup configuration \n&6Permission: &7" + registry.getPlugin().getPluginNamePrefixLong() + ".admin.setup")) {

--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/handlers/items/SpecialItem.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/handlers/items/SpecialItem.java
@@ -157,12 +157,12 @@ public class SpecialItem {
   }
 
   public void setItem(Player player) {
-    PlayerInventory playerInventory = player.getInventory();
-    ItemStack itemStack = getItemStack();
     if(!move) {
-      HandlerItem handlerItem = new HandlerItem(itemStack);
-      handlerItem.setMovementCancel(true);
+      new HandlerItem(itemStack).setMovementCancel(true);
     }
+
+    PlayerInventory playerInventory = player.getInventory();
+
     if(!force) {
       ItemStack slotItem = playerInventory.getItem(slot);
       if(slotItem == null) {

--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/handlers/items/SpecialItemEvent.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/handlers/items/SpecialItemEvent.java
@@ -50,12 +50,12 @@ public class SpecialItemEvent implements Listener {
     if(!ItemUtils.isItemStackNamed(itemStack)) {
       return false;
     }
-    PluginArena arena = plugin.getArenaRegistry().getArena(player);
-    if(arena == null) {
+
+    if(!plugin.getArenaRegistry().isInArena(player)) {
       return false;
     }
-    SpecialItem key = plugin.getSpecialItemManager().getRelatedSpecialItem(itemStack);
-    return key != plugin.getSpecialItemManager().getInvalidItem();
+
+    return plugin.getSpecialItemManager().getRelatedSpecialItem(itemStack) != plugin.getSpecialItemManager().getInvalidItem();
   }
 
   @EventHandler
@@ -71,7 +71,6 @@ public class SpecialItemEvent implements Listener {
       return;
     }
     Player player = event.getPlayer();
-    PluginArena arena = plugin.getArenaRegistry().getArena(player);
 
     ItemStack itemStack = VersionUtils.getItemInHand(player);
     if(!ItemUtils.isItemStackNamed(itemStack)) {
@@ -84,12 +83,14 @@ public class SpecialItemEvent implements Listener {
     }
     plugin.getDebugger().debug("Found the item " + relatedSpecialItem.getPath());
     event.setCancelled(true);
-    if(relatedSpecialItem.getPermission() != null && !relatedSpecialItem.getPermission().equalsIgnoreCase("")) {
+    if(relatedSpecialItem.getPermission() != null && !relatedSpecialItem.getPermission().isEmpty()) {
       if(!plugin.getBukkitHelper().hasPermission(player, relatedSpecialItem.getPermission())) {
         return;
       }
     }
     plugin.getDebugger().debug("SpecialItem {0} - Permission check for {1} true", relatedSpecialItem.getPath(), player.getName());
+
+    PluginArena arena = plugin.getArenaRegistry().getArena(player);
 
     if(arena == null) {
       plugin.getRewardsHandler().performReward(player, relatedSpecialItem.getRewards());

--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/handlers/language/MessageManager.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/handlers/language/MessageManager.java
@@ -68,10 +68,13 @@ public class MessageManager {
    * @return Message
    */
   public Message getMessage(String name) {
-    if(!options.containsKey(name)) {
+    Message message = options.get(name);
+
+    if(message == null) {
       throw new IllegalStateException("Message with name " + name + " does not exist");
     }
-    return options.get(name);
+
+    return message;
   }
 
   /**
@@ -81,10 +84,13 @@ public class MessageManager {
    * @return String path
    */
   public String getPath(String name) {
-    if(!options.containsKey(name)) {
+    Message message = options.get(name);
+
+    if(message == null) {
       throw new IllegalStateException("Message with name " + name + " does not exist");
     }
-    return options.get(name).getPath();
+
+    return message.getPath();
   }
 
   /**

--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/handlers/permissions/PermissionsManager.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/handlers/permissions/PermissionsManager.java
@@ -61,10 +61,13 @@ public class PermissionsManager {
    * @return Permission
    */
   public Permission getPermission(String key) {
-    if(!permissions.containsKey(key)) {
+    Permission permission = permissions.get(key);
+
+    if(permission == null) {
       throw new IllegalStateException("Permission with key " + key + " does not exist");
     }
-    return permissions.get(key);
+
+    return permission;
   }
 
 
@@ -75,10 +78,13 @@ public class PermissionsManager {
    * @return String the permission
    */
   public String getPermissionString(String key) {
-    if(!permissions.containsKey(key)) {
+    Permission permission = permissions.get(key);
+
+    if(permission == null) {
       throw new IllegalStateException("Permission with key " + key + " does not exist");
     }
-    return permissions.get(key).getPermission();
+
+    return permission.getPermission();
   }
 
   /**
@@ -88,10 +94,13 @@ public class PermissionsManager {
    * @return String the permission
    */
   public boolean hasPermissionString(String key, Player player) {
-    if(!permissions.containsKey(key)) {
+    Permission permission = permissions.get(key);
+
+    if(permission == null) {
       throw new IllegalStateException("Permission with key " + key + " does not exist");
     }
-    return player.hasPermission(permissions.get(key).getPermission());
+
+    return player.hasPermission(permission.getPermission());
   }
 
   /**
@@ -145,10 +154,13 @@ public class PermissionsManager {
    * @return PermissionCategory
    */
   public PermissionCategory getPermissionCategory(String key) {
-    if(!permissionCategories.containsKey(key)) {
+    PermissionCategory permissionCategory = permissionCategories.get(key);
+
+    if(permissionCategory == null) {
       throw new IllegalStateException("Permission category with key " + key + " does not exist");
     }
-    return permissionCategories.get(key);
+
+    return permissionCategory;
   }
 
   /**
@@ -158,10 +170,13 @@ public class PermissionsManager {
    * @return Map permissionCategoryMap
    */
   public Map<String, Integer> getPermissionCategoryMap(String key) {
-    if(!permissionCategories.containsKey(key)) {
+    PermissionCategory permissionCategory = permissionCategories.get(key);
+
+    if(permissionCategory == null) {
       throw new IllegalStateException("Permission category with key " + key + " does not exist");
     }
-    return permissionCategories.get(key).getCustomPermissions();
+
+    return permissionCategory.getCustomPermissions();
   }
 
   /**

--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/handlers/reward/RewardsFactory.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/handlers/reward/RewardsFactory.java
@@ -70,10 +70,13 @@ public class RewardsFactory {
    * @return RewardType
    */
   public RewardType getRewardType(String key) {
-    if(!rewardTypes.containsKey(key)) {
+    RewardType rewardType = rewardTypes.get(key);
+
+    if(rewardType == null) {
       throw new IllegalStateException("RewardType with name " + key + " does not exist");
     }
-    return rewardTypes.get(key);
+
+    return rewardType;
   }
 
   /**
@@ -153,7 +156,7 @@ public class RewardsFactory {
       return;
     }
     String command = reward.getExecutableCode();
-    if(command == null || command.equalsIgnoreCase("")) {
+    if(command == null || command.isEmpty()) {
       return;
     }
     MessageBuilder messageBuilder = new MessageBuilder(command, false);

--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/preferences/ConfigPreferences.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/preferences/ConfigPreferences.java
@@ -71,10 +71,13 @@ public class ConfigPreferences {
    * @return true or false based on user configuration
    */
   public boolean getOption(String name) {
-    if(!options.containsKey(name)) {
+    ConfigOption configOption = options.get(name);
+
+    if(configOption == null) {
       throw new IllegalStateException("Option with name " + name + " does not exist");
     }
-    return options.get(name).getValue();
+
+    return configOption.getValue();
   }
 
 

--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/user/User.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/user/User.java
@@ -102,8 +102,7 @@ public class User {
   }
 
   public int getStatistic(String statistic) {
-    StatisticType statisticType = plugin.getStatsStorage().getStatisticType(statistic.toUpperCase());
-    return getStatistic(statisticType);
+    return getStatistic(plugin.getStatsStorage().getStatisticType(statistic.toUpperCase()));
   }
 
   public int getStatistic(StatisticType statisticType) {
@@ -115,18 +114,22 @@ public class User {
   }
 
   public void setStatistic(String statistic, int value) {
-    StatisticType statisticType = plugin.getStatsStorage().getStatisticType(statistic);
-    changeUserStatistic(statisticType, value);
+    changeUserStatistic(plugin.getStatsStorage().getStatisticType(statistic), value);
   }
 
   private void changeUserStatistic(StatisticType statisticType, int value) {
     stats.put(statisticType, value);
-    plugin.getDebugger().debug("Set User {0} statistic to {1} for {2} ", statisticType.getName(), value, getPlayer().getName());
-    //statistics manipulation events are called async when using mysql
-    Bukkit.getScheduler().runTask(plugin, () -> {
-      Player player = getPlayer();
-      Bukkit.getPluginManager().callEvent(new PlugilyPlayerStatisticChangeEvent(plugin.getArenaRegistry().getArena(player), player, statisticType, value));
-    });
+
+    Player player = getPlayer();
+
+    if (player != null) {
+      plugin.getDebugger().debug("Set User {0} statistic to {1} for {2} ", statisticType.getName(), value, player.getName());
+
+      //statistics manipulation events are called async when using mysql
+      Bukkit.getScheduler().runTask(plugin, () -> {
+        Bukkit.getPluginManager().callEvent(new PlugilyPlayerStatisticChangeEvent(plugin.getArenaRegistry().getArena(player), player, statisticType, value));
+      });
+    }
   }
 
   public void adjustStatistic(StatisticType statisticType, int value) {

--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/user/UserManager.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/user/UserManager.java
@@ -31,7 +31,6 @@ import plugily.projects.minigamesbox.classic.user.data.UserDatabase;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * @author Tigerpanzer_02
@@ -74,7 +73,13 @@ public class UserManager {
   }
 
   public List<User> getUsers(PluginArena arena) {
-    return arena.getPlayers().stream().map(this::getUser).collect(Collectors.toList());
+    List<User> users = new ArrayList<>(arena.getPlayers().size());
+
+    for (Player player : arena.getPlayers()) {
+      users.add(getUser(player));
+    }
+
+    return users;
   }
 
   public void saveStatistic(User user, StatisticType stat) {
@@ -101,12 +106,18 @@ public class UserManager {
   }
 
   public void updateLevelStat(User user, PluginArena arena) {
-    if(user.getStatistic(plugin.getStatsStorage().getStatisticType("NEXT_LEVEL_EXP")) < user.getStatistic(plugin.getStatsStorage().getStatisticType("EXP"))) {
+    StatisticType nextLevelExp = plugin.getStatsStorage().getStatisticType("NEXT_LEVEL_EXP");
+
+    if(user.getStatistic(nextLevelExp) < user.getStatistic(plugin.getStatsStorage().getStatisticType("EXP"))) {
       user.adjustStatistic(plugin.getStatsStorage().getStatisticType("LEVEL"), 1);
-      user.setStatistic(plugin.getStatsStorage().getStatisticType("NEXT_LEVEL_EXP"), (int) Math.ceil(Math.pow(50.0 * user.getStatistic(plugin.getStatsStorage().getStatisticType("LEVEL")), 1.5)));
+
+      int level = user.getStatistic(plugin.getStatsStorage().getStatisticType("LEVEL"));
+
+      user.setStatistic(nextLevelExp, (int) Math.ceil(Math.pow(50.0 * level, 1.5)));
+
       //Arena can be null when player has left the arena before this message is retrieved.
       if(arena != null)
-        new MessageBuilder("IN_GAME_LEVEL_UP").asKey().arena(arena).player(user.getPlayer()).integer(user.getStatistic(plugin.getStatsStorage().getStatisticType("LEVEL"))).sendPlayer();
+        new MessageBuilder("IN_GAME_LEVEL_UP").asKey().arena(arena).player(user.getPlayer()).integer(level).sendPlayer();
     }
   }
 

--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/utils/serialization/LocationSerializer.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/utils/serialization/LocationSerializer.java
@@ -68,14 +68,19 @@ public class LocationSerializer {
    * @see #saveLoc(JavaPlugin, FileConfiguration, String, String, Location)
    */
   public static Location getLocation(String path) {
-    String[] loc;
-    if(path == null || (loc = path.split(",")).length == 0) {
+    if (path == null)
+      return null;
+
+    String[] loc = path.split(",");
+
+    if(loc.length == 0) {
       return null;
     }
 
-    World world = Bukkit.getServer().getWorld(loc[0]);
+    String worldName = loc[0];
+    World world = Bukkit.getServer().getWorld(worldName);
     if(world == null && !Bukkit.getPluginManager().isPluginEnabled("Multiverse-Core")) {
-      world = Bukkit.createWorld(new WorldCreator(loc[0]));
+      world = Bukkit.createWorld(new WorldCreator(worldName));
     }
 
     if(loc.length == 1) {

--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/utils/version/PacketUtils.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/utils/version/PacketUtils.java
@@ -19,6 +19,9 @@
 
 package plugily.projects.minigamesbox.classic.utils.version;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
 import org.bukkit.entity.Player;
 
 /**
@@ -28,26 +31,32 @@ import org.bukkit.entity.Player;
  */
 public class PacketUtils {
 
-  private static Class<?> packetClass;
+  private static Method getHandleMethod, sendPacketMethod;
+  private static Field playerConnectionField;
 
   static {
-    packetClass = classByName("net.minecraft.network.protocol", "Packet");
+    try {
+      getHandleMethod = Player.class.getMethod("getHandle");
+    } catch (NoSuchMethodException | SecurityException e) {
+      e.printStackTrace();
+    }
   }
 
   public static void sendPacket(Player player, Object packet) {
     try {
-      Object handle = player.getClass().getMethod("getHandle").invoke(player);
-      Object playerConnection = handle.getClass().getField(
-          (ServerVersion.Version.isCurrentEqualOrHigher(ServerVersion.Version.v1_17_R1) ? "b" : "playerConnection")).get(handle);
-      playerConnection.getClass().getMethod((ServerVersion.Version.isCurrentEqualOrHigher(ServerVersion.Version.v1_18_R1) ? "a" : "sendPacket"), packetClass).invoke(playerConnection, packet);
-/*
-java.lang.IllegalArgumentException: argument type mismatch
-	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
-	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77) ~[?:?]
-	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
-	at java.lang.reflect.Method.invoke(Method.java:568) ~[?:?]
-	at plugily.projects.buildbattle.minigamesbox.classic.utils.version.PacketUtils.sendPacket(PacketUtils.java:42)
- */
+      Object handle = getHandleMethod.invoke(player);
+
+      if (playerConnectionField == null)
+        playerConnectionField = handle.getClass().getField(
+              (ServerVersion.Version.isCurrentEqualOrHigher(ServerVersion.Version.v1_17_R1) ? "b" : "playerConnection"));
+
+      Object playerConnection = playerConnectionField.get(handle);
+
+      if (sendPacketMethod == null)
+        sendPacketMethod = playerConnection.getClass().getMethod((ServerVersion.Version.isCurrentEqualOrHigher(ServerVersion.Version.v1_18_R1) ? "a" : "sendPacket"),
+            classByName("net.minecraft.network.protocol", "Packet"));
+
+      sendPacketMethod.invoke(playerConnection, packet);
     } catch(ReflectiveOperationException ex) {
       ex.printStackTrace();
     }


### PR DESCRIPTION
This PR is focusing on performance especially to avoid streams where possible and may impact the overall performance. Calling `Map#containsKey` and `Map#get` is the same which means we can cache the `Map#get` result to a variable and use it, if the map does not contain the specified key it will returns null, otherwise returns the cached value. Streams should be avoided in places like in PluginArena class within `getPlayersLeft` method as this method is used often. In case if we want streams in our code it can be safely used in our starting method, like where the plugin will load in `onEnable` method and its contents. Also removed some one time used variables which is pretty useless to cache to memory.