### PR TITLE
Wait for the teleportation process to be done before adding items to players

### DIFF
--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/arena/PluginArenaManager.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/arena/PluginArenaManager.java
@@ -77,41 +77,48 @@ public class PluginArenaManager {
         new MessageBuilder("IN_GAME_SPECTATOR_BLOCKED").asKey().player(player).arena(arena).sendPlayer();
         return;
       }
-      PluginArenaUtils.preparePlayerForGame(arena, player, arena.getSpectatorLocation(), true);
-      new MessageBuilder("IN_GAME_SPECTATOR_YOU_ARE_SPECTATOR").asKey().player(player).arena(arena).sendPlayer();
-      PluginArenaUtils.hidePlayer(player, arena);
-      for(Player spectator : arena.getPlayers()) {
-        if(plugin.getUserManager().getUser(spectator).isSpectator()) {
-          VersionUtils.hidePlayer(plugin, player, spectator);
-        } else {
-          VersionUtils.showPlayer(plugin, player, spectator);
+
+      PluginArenaUtils.preparePlayerForGame(arena, player, arena.getSpectatorLocation(), true).thenAccept(v -> {
+        new MessageBuilder("IN_GAME_SPECTATOR_YOU_ARE_SPECTATOR").asKey().player(player).arena(arena).sendPlayer();
+        PluginArenaUtils.hidePlayer(player, arena);
+
+        for(Player spectator : arena.getPlayers()) {
+          if(plugin.getUserManager().getUser(spectator).isSpectator()) {
+            VersionUtils.hidePlayer(plugin, player, spectator);
+          } else {
+            VersionUtils.showPlayer(plugin, player, spectator);
+          }
         }
-      }
-      additionalSpectatorSettings(player, arena);
-      plugin.getDebugger().debug("[{0}] Final join attempt as spectator for {1} took {2}ms", arena.getId(), player.getName(), System.currentTimeMillis() - start);
+
+        additionalSpectatorSettings(player, arena);
+        plugin.getDebugger().debug("[{0}] Final join attempt as spectator for {1} took {2}ms", arena.getId(), player.getName(), System.currentTimeMillis() - start);
+      });
+
       return;
     }
 
-    PluginArenaUtils.preparePlayerForGame(arena, player, arena.getLobbyLocation(), false);
+    PluginArenaUtils.preparePlayerForGame(arena, player, arena.getLobbyLocation(), false).thenAccept(v -> {
+      arena.getBossbarManager().doBarAction(PluginArena.BarAction.ADD, player);
+      new MessageBuilder(MessageBuilder.ActionType.JOIN).arena(arena).player(player).sendArena();
 
-    arena.getBossbarManager().doBarAction(PluginArena.BarAction.ADD, player);
+      plugin.getUserManager().getUser(player).setKit(plugin.getKitRegistry().getDefaultKit());
+      plugin.getSpecialItemManager().addSpecialItemsOfStage(player, SpecialItem.DisplayStage.LOBBY);
 
-    new MessageBuilder(MessageBuilder.ActionType.JOIN).arena(arena).player(player).sendArena();
+      if(arena.getArenaState() == ArenaState.WAITING_FOR_PLAYERS) {
+        plugin.getSpecialItemManager().addSpecialItemsOfStage(player, SpecialItem.DisplayStage.WAITING_FOR_PLAYERS);
+      } else if(arena.getArenaState().isStartingStage(arena)) {
+        plugin.getSpecialItemManager().addSpecialItemsOfStage(player, SpecialItem.DisplayStage.ENOUGH_PLAYERS_TO_START);
+      }
 
-    plugin.getUserManager().getUser(player).setKit(plugin.getKitRegistry().getDefaultKit());
-    plugin.getSpecialItemManager().addSpecialItemsOfStage(player, SpecialItem.DisplayStage.LOBBY);
-    if(arena.getArenaState() == ArenaState.WAITING_FOR_PLAYERS) {
-      plugin.getSpecialItemManager().addSpecialItemsOfStage(player, SpecialItem.DisplayStage.WAITING_FOR_PLAYERS);
-    } else if(arena.getArenaState().isStartingStage(arena)) {
-      plugin.getSpecialItemManager().addSpecialItemsOfStage(player, SpecialItem.DisplayStage.ENOUGH_PLAYERS_TO_START);
-    }
+      for(Player arenaPlayer : arena.getPlayers()) {
+        PluginArenaUtils.showPlayer(arenaPlayer, arena);
+      }
 
-    for(Player arenaPlayer : arena.getPlayers()) {
-      PluginArenaUtils.showPlayer(arenaPlayer, arena);
-    }
-    new TitleBuilder("IN_GAME_JOIN_TITLE").asKey().arena(arena).player(player).sendPlayer();
-    plugin.getSignManager().updateSigns();
-    plugin.getDebugger().debug("[{0}] Final join attempt as player for {1} took {2}ms", arena.getId(), player.getName(), System.currentTimeMillis() - start);
+      new TitleBuilder("IN_GAME_JOIN_TITLE").asKey().arena(arena).player(player).sendPlayer();
+
+      plugin.getSignManager().updateSigns();
+      plugin.getDebugger().debug("[{0}] Final join attempt as player for {1} took {2}ms", arena.getId(), player.getName(), System.currentTimeMillis() - start);
+    });
   }
 
   private boolean joinAsParty(@NotNull Player player, @NotNull PluginArena arena) {

--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/arena/PluginArenaUtils.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/arena/PluginArenaUtils.java
@@ -70,50 +70,55 @@ public class PluginArenaUtils {
     }
   }
 
-  public static void preparePlayerForGame(
-      PluginArena arena, Player player, Location location, boolean spectator) {
-    User user = plugin.getUserManager().getUser(player);
-    if(plugin.getConfigPreferences().getOption("INVENTORY_MANAGER")) {
-      InventorySerializer.saveInventoryToFile(plugin, player);
-    }
-    VersionUtils.teleport(player, location);
-    player.getInventory().clear();
-    player
-        .getActivePotionEffects()
-        .forEach(potionEffect -> player.removePotionEffect(potionEffect.getType()));
-    VersionUtils.setMaxHealth(player, VersionUtils.getMaxHealth(player));
-    player.setHealth(VersionUtils.getMaxHealth(player));
-    player.setFoodLevel(20);
-    player.setGameMode(GameMode.SURVIVAL);
-    player
-        .getInventory()
-        .setArmorContents(
-            new ItemStack[]{
-                new ItemStack(Material.AIR),
-                new ItemStack(Material.AIR),
-                new ItemStack(Material.AIR),
-                new ItemStack(Material.AIR)
-            });
-    player.setExp(1);
-    player.setLevel(0);
-    player.setWalkSpeed(0.2f);
-    player.setFlySpeed(0.1f);
+  public static void preparePlayerForGame(PluginArena arena, Player player, Location location, boolean spectator) {
+    VersionUtils.teleport(player, location).thenAccept(bol -> {
+      if(plugin.getConfigPreferences().getOption("INVENTORY_MANAGER")) {
+        InventorySerializer.saveInventoryToFile(plugin, player);
+      }
+      
+      player.getInventory().clear();
+      player
+          .getActivePotionEffects()
+          .forEach(potionEffect -> player.removePotionEffect(potionEffect.getType()));
 
-    if(spectator) {
-      player.setAllowFlight(true);
-      player.setFlying(true);
-      user.setSpectator(true);
-      player.addPotionEffect(new PotionEffect(PotionEffectType.NIGHT_VISION, Integer.MAX_VALUE, 0));
-      plugin
-          .getSpecialItemManager()
-          .addSpecialItemsOfStage(player, SpecialItem.DisplayStage.SPECTATOR);
-    } else {
-      player.setAllowFlight(false);
-      player.setFlying(false);
-      user.setSpectator(false);
-    }
-    player.updateInventory();
-    arena.getScoreboardManager().createScoreboard(user);
+      double maxHealth = VersionUtils.getMaxHealth(player);
+      VersionUtils.setMaxHealth(player, maxHealth);
+      player.setHealth(maxHealth);
+
+      player.setFoodLevel(20);
+      player.setGameMode(GameMode.SURVIVAL);
+      player
+          .getInventory()
+          .setArmorContents(
+              new ItemStack[]{
+                  new ItemStack(Material.AIR),
+                  new ItemStack(Material.AIR),
+                  new ItemStack(Material.AIR),
+                  new ItemStack(Material.AIR)
+              });
+      player.setExp(1);
+      player.setLevel(0);
+      player.setWalkSpeed(0.2f);
+      player.setFlySpeed(0.1f);
+
+      User user = plugin.getUserManager().getUser(player);
+
+      if(spectator) {
+        player.setAllowFlight(true);
+        player.setFlying(true);
+        user.setSpectator(true);
+        player.addPotionEffect(new PotionEffect(PotionEffectType.NIGHT_VISION, Integer.MAX_VALUE, 0));
+        plugin
+            .getSpecialItemManager()
+            .addSpecialItemsOfStage(player, SpecialItem.DisplayStage.SPECTATOR);
+      } else {
+        player.setAllowFlight(false);
+        player.setFlying(false);
+        user.setSpectator(false);
+      }
+      player.updateInventory();
+      arena.getScoreboardManager().createScoreboard(user);
+    });
   }
 
   public static void resetPlayerAfterGame(Player player) {

--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/arena/PluginArenaUtils.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/arena/PluginArenaUtils.java
@@ -19,6 +19,8 @@
 
 package plugily.projects.minigamesbox.classic.arena;
 
+import java.util.concurrent.CompletableFuture;
+
 import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -70,16 +72,14 @@ public class PluginArenaUtils {
     }
   }
 
-  public static void preparePlayerForGame(PluginArena arena, Player player, Location location, boolean spectator) {
-    VersionUtils.teleport(player, location).thenAccept(bol -> {
+  public static CompletableFuture<Void> preparePlayerForGame(PluginArena arena, Player player, Location location, boolean spectator) {
+    return VersionUtils.teleport(player, location).thenAccept(bol -> {
       if(plugin.getConfigPreferences().getOption("INVENTORY_MANAGER")) {
         InventorySerializer.saveInventoryToFile(plugin, player);
       }
-      
+
       player.getInventory().clear();
-      player
-          .getActivePotionEffects()
-          .forEach(potionEffect -> player.removePotionEffect(potionEffect.getType()));
+      player.getActivePotionEffects().forEach(potionEffect -> player.removePotionEffect(potionEffect.getType()));
 
       double maxHealth = VersionUtils.getMaxHealth(player);
       VersionUtils.setMaxHealth(player, maxHealth);
@@ -87,9 +87,7 @@ public class PluginArenaUtils {
 
       player.setFoodLevel(20);
       player.setGameMode(GameMode.SURVIVAL);
-      player
-          .getInventory()
-          .setArmorContents(
+      player.getInventory().setArmorContents(
               new ItemStack[]{
                   new ItemStack(Material.AIR),
                   new ItemStack(Material.AIR),
@@ -108,9 +106,7 @@ public class PluginArenaUtils {
         player.setFlying(true);
         user.setSpectator(true);
         player.addPotionEffect(new PotionEffect(PotionEffectType.NIGHT_VISION, Integer.MAX_VALUE, 0));
-        plugin
-            .getSpecialItemManager()
-            .addSpecialItemsOfStage(player, SpecialItem.DisplayStage.SPECTATOR);
+        plugin.getSpecialItemManager().addSpecialItemsOfStage(player, SpecialItem.DisplayStage.SPECTATOR);
       } else {
         player.setAllowFlight(false);
         player.setFlying(false);

--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/utils/version/VersionUtils.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/utils/version/VersionUtils.java
@@ -63,6 +63,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -171,20 +172,19 @@ public final class VersionUtils {
 
   private static JavaPlugin plugin;
 
-  public static void teleport(Entity entity, Location location) {
+  public static CompletableFuture<Boolean> teleport(Entity entity, Location location) {
     if(isPaper) {
       // Avoid Future.get() method to be called from the main thread
 
       if(Bukkit.isPrimaryThread()) { // Checks if the current thread is not async
-        PaperLib.teleportAsync(entity, location);
-        return;
+        return PaperLib.teleportAsync(entity, location);
       }
 
       if(plugin == null)
         plugin = JavaPlugin.getPlugin(PluginMain.class);
 
       try {
-        Bukkit.getScheduler().callSyncMethod(plugin, () -> PaperLib.teleportAsync(entity, location)).get();
+        return Bukkit.getScheduler().callSyncMethod(plugin, () -> PaperLib.teleportAsync(entity, location)).get();
       } catch(InterruptedException | ExecutionException e) {
         e.printStackTrace();
       } catch(CancellationException e) {
@@ -193,6 +193,8 @@ public final class VersionUtils {
     } else {
       entity.teleport(location);
     }
+
+    return new CompletableFuture<>();
   }
 
   public static void sendParticles(String particleName, Player player, Location location, int count) {


### PR DESCRIPTION
Paper implemented a way to perform an entity teleportation asynchronously and we need to wait for this async thread to be done before for example adding items to players as there could be per-world items set for specific servers. So the teleport should happen earlier.

https://discord.com/channels/345628548716822530/993238249067786291/1039589266298253393