### PR TITLE
Fix teleporting between worlds

### DIFF
--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/arena/PluginArenaManager.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/arena/PluginArenaManager.java
@@ -77,41 +77,42 @@ public class PluginArenaManager {
         new MessageBuilder("IN_GAME_SPECTATOR_BLOCKED").asKey().player(player).arena(arena).sendPlayer();
         return;
       }
-      PluginArenaUtils.preparePlayerForGame(arena, player, arena.getSpectatorLocation(), true);
-      new MessageBuilder("IN_GAME_SPECTATOR_YOU_ARE_SPECTATOR").asKey().player(player).arena(arena).sendPlayer();
-      PluginArenaUtils.hidePlayer(player, arena);
-      for(Player spectator : arena.getPlayers()) {
-        if(plugin.getUserManager().getUser(spectator).isSpectator()) {
-          VersionUtils.hidePlayer(plugin, player, spectator);
-        } else {
-          VersionUtils.showPlayer(plugin, player, spectator);
+      PluginArenaUtils.preparePlayerForGame(arena, player, arena.getSpectatorLocation(), true).thenAccept(act -> {
+        new MessageBuilder("IN_GAME_SPECTATOR_YOU_ARE_SPECTATOR").asKey().player(player).arena(arena).sendPlayer();
+        PluginArenaUtils.hidePlayer(player, arena);
+        for (Player spectator : arena.getPlayers()) {
+          if (plugin.getUserManager().getUser(spectator).isSpectator()) {
+            VersionUtils.hidePlayer(plugin, player, spectator);
+          } else {
+            VersionUtils.showPlayer(plugin, player, spectator);
+          }
         }
-      }
-      additionalSpectatorSettings(player, arena);
-      plugin.getDebugger().debug("[{0}] Final join attempt as spectator for {1} took {2}ms", arena.getId(), player.getName(), System.currentTimeMillis() - start);
+        additionalSpectatorSettings(player, arena);
+        plugin.getDebugger().debug("[{0}] Final join attempt as spectator for {1} took {2}ms", arena.getId(), player.getName(), System.currentTimeMillis() - start);
+      });
       return;
     }
 
-    PluginArenaUtils.preparePlayerForGame(arena, player, arena.getLobbyLocation(), false);
+    PluginArenaUtils.preparePlayerForGame(arena, player, arena.getLobbyLocation(), false).thenAccept(act -> {
+      arena.getBossbarManager().doBarAction(PluginArena.BarAction.ADD, player);
 
-    arena.getBossbarManager().doBarAction(PluginArena.BarAction.ADD, player);
+      new MessageBuilder(MessageBuilder.ActionType.JOIN).arena(arena).player(player).sendArena();
 
-    new MessageBuilder(MessageBuilder.ActionType.JOIN).arena(arena).player(player).sendArena();
+      plugin.getUserManager().getUser(player).setKit(plugin.getKitRegistry().getDefaultKit());
+      plugin.getSpecialItemManager().addSpecialItemsOfStage(player, SpecialItem.DisplayStage.LOBBY);
+      if (arena.getArenaState() == ArenaState.WAITING_FOR_PLAYERS) {
+        plugin.getSpecialItemManager().addSpecialItemsOfStage(player, SpecialItem.DisplayStage.WAITING_FOR_PLAYERS);
+      } else if (arena.getArenaState().isStartingStage(arena)) {
+        plugin.getSpecialItemManager().addSpecialItemsOfStage(player, SpecialItem.DisplayStage.ENOUGH_PLAYERS_TO_START);
+      }
 
-    plugin.getUserManager().getUser(player).setKit(plugin.getKitRegistry().getDefaultKit());
-    plugin.getSpecialItemManager().addSpecialItemsOfStage(player, SpecialItem.DisplayStage.LOBBY);
-    if(arena.getArenaState() == ArenaState.WAITING_FOR_PLAYERS) {
-      plugin.getSpecialItemManager().addSpecialItemsOfStage(player, SpecialItem.DisplayStage.WAITING_FOR_PLAYERS);
-    } else if(arena.getArenaState().isStartingStage(arena)) {
-      plugin.getSpecialItemManager().addSpecialItemsOfStage(player, SpecialItem.DisplayStage.ENOUGH_PLAYERS_TO_START);
-    }
-
-    for(Player arenaPlayer : arena.getPlayers()) {
-      PluginArenaUtils.showPlayer(arenaPlayer, arena);
-    }
-    new TitleBuilder("IN_GAME_JOIN_TITLE").asKey().arena(arena).player(player).sendPlayer();
-    plugin.getSignManager().updateSigns();
-    plugin.getDebugger().debug("[{0}] Final join attempt as player for {1} took {2}ms", arena.getId(), player.getName(), System.currentTimeMillis() - start);
+      for (Player arenaPlayer : arena.getPlayers()) {
+        PluginArenaUtils.showPlayer(arenaPlayer, arena);
+      }
+      new TitleBuilder("IN_GAME_JOIN_TITLE").asKey().arena(arena).player(player).sendPlayer();
+      plugin.getSignManager().updateSigns();
+      plugin.getDebugger().debug("[{0}] Final join attempt as player for {1} took {2}ms", arena.getId(), player.getName(), System.currentTimeMillis() - start);
+    });
   }
 
   private boolean joinAsParty(@NotNull Player player, @NotNull PluginArena arena) {

--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/arena/PluginArenaUtils.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/arena/PluginArenaUtils.java
@@ -33,6 +33,8 @@ import plugily.projects.minigamesbox.classic.user.User;
 import plugily.projects.minigamesbox.classic.utils.serialization.InventorySerializer;
 import plugily.projects.minigamesbox.classic.utils.version.VersionUtils;
 
+import java.util.concurrent.CompletableFuture;
+
 /**
  * @author Tigerpanzer_02
  * <p>Created at 01.11.2021
@@ -70,50 +72,52 @@ public class PluginArenaUtils {
     }
   }
 
-  public static void preparePlayerForGame(
+  public static CompletableFuture<Void> preparePlayerForGame(
       PluginArena arena, Player player, Location location, boolean spectator) {
-    User user = plugin.getUserManager().getUser(player);
-    if(plugin.getConfigPreferences().getOption("INVENTORY_MANAGER")) {
-      InventorySerializer.saveInventoryToFile(plugin, player);
-    }
-    VersionUtils.teleport(player, location);
-    player.getInventory().clear();
-    player
-        .getActivePotionEffects()
-        .forEach(potionEffect -> player.removePotionEffect(potionEffect.getType()));
-    VersionUtils.setMaxHealth(player, VersionUtils.getMaxHealth(player));
-    player.setHealth(VersionUtils.getMaxHealth(player));
-    player.setFoodLevel(20);
-    player.setGameMode(GameMode.SURVIVAL);
-    player
-        .getInventory()
-        .setArmorContents(
-            new ItemStack[]{
-                new ItemStack(Material.AIR),
-                new ItemStack(Material.AIR),
-                new ItemStack(Material.AIR),
-                new ItemStack(Material.AIR)
-            });
-    player.setExp(1);
-    player.setLevel(0);
-    player.setWalkSpeed(0.2f);
-    player.setFlySpeed(0.1f);
+    return VersionUtils.teleport(player, location).thenAccept(bo -> {
+      User user = plugin.getUserManager().getUser(player);
+      if (plugin.getConfigPreferences().getOption("INVENTORY_MANAGER")) {
+        InventorySerializer.saveInventoryToFile(plugin, player);
+      }
 
-    if(spectator) {
-      player.setAllowFlight(true);
-      player.setFlying(true);
-      user.setSpectator(true);
-      player.addPotionEffect(new PotionEffect(PotionEffectType.NIGHT_VISION, Integer.MAX_VALUE, 0));
-      plugin
-          .getSpecialItemManager()
-          .addSpecialItemsOfStage(player, SpecialItem.DisplayStage.SPECTATOR);
-    } else {
-      player.setAllowFlight(false);
-      player.setFlying(false);
-      user.setSpectator(false);
-    }
-    player.updateInventory();
-    arena.getScoreboardManager().createScoreboard(user);
+      player.getInventory().clear();
+      player
+              .getActivePotionEffects()
+              .forEach(potionEffect -> player.removePotionEffect(potionEffect.getType()));
+      VersionUtils.setMaxHealth(player, VersionUtils.getMaxHealth(player));
+      player.setHealth(VersionUtils.getMaxHealth(player));
+      player.setFoodLevel(20);
+      player.setGameMode(GameMode.SURVIVAL);
+      player
+              .getInventory()
+              .setArmorContents(
+                      new ItemStack[] {
+                              new ItemStack(Material.AIR),
+                              new ItemStack(Material.AIR),
+                              new ItemStack(Material.AIR),
+                              new ItemStack(Material.AIR)
+                      });
+      player.setExp(1);
+      player.setLevel(0);
+      player.setWalkSpeed(0.2f);
+      player.setFlySpeed(0.1f);
+
+      if (spectator) {
+        player.setAllowFlight(true);
+        player.setFlying(true);
+        user.setSpectator(true);
+        player.addPotionEffect(new PotionEffect(PotionEffectType.NIGHT_VISION, Integer.MAX_VALUE, 0));
+        plugin
+                .getSpecialItemManager()
+                .addSpecialItemsOfStage(player, SpecialItem.DisplayStage.SPECTATOR);
+      } else {
+        player.setAllowFlight(false);
+        player.setFlying(false);
+        user.setSpectator(false);
+      }
+      player.updateInventory();
+      arena.getScoreboardManager().createScoreboard(user);
+    });
   }
 
   public static void resetPlayerAfterGame(Player player) {

--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/arena/states/PluginStartingState.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/arena/states/PluginStartingState.java
@@ -96,20 +96,21 @@ public class PluginStartingState implements ArenaStateHandler {
       arena.getBossbarManager().setProgress(1.0);
       org.bukkit.Location arenaLoc = arena.getStartLocation();
       for(Player player : arena.getPlayers()) {
-        VersionUtils.teleport(player, arenaLoc);
-        PluginArenaUtils.hidePlayersOutsideTheGame(player, arena);
-        player.setExp(0);
-        player.setLevel(0);
-        player.getInventory().clear();
-        player.setGameMode(GameMode.SURVIVAL);
-        User user = plugin.getUserManager().getUser(player);
-        user.getKit().giveKitItems(player);
-        player.updateInventory();
-        plugin.getUserManager().addExperience(player, 10);
-        new MessageBuilder("IN_GAME_MESSAGES_LOBBY_GAME_START").asKey().arena(arena).player(player).sendPlayer();
-        plugin.getSpecialItemManager().addSpecialItemsOfStage(player, SpecialItem.DisplayStage.IN_GAME);
-        plugin.getRewardsHandler().performReward(player, arena, plugin.getRewardsHandler().getRewardType("START_GAME"));
-        plugin.getUserManager().addStat(user, plugin.getStatsStorage().getStatisticType("GAMES_PLAYED"));
+        VersionUtils.teleport(player, arenaLoc).thenAccept(bol -> {
+          PluginArenaUtils.hidePlayersOutsideTheGame(player, arena);
+          player.setExp(0);
+          player.setLevel(0);
+          player.getInventory().clear();
+          player.setGameMode(GameMode.SURVIVAL);
+          User user = plugin.getUserManager().getUser(player);
+          user.getKit().giveKitItems(player);
+          player.updateInventory();
+          plugin.getUserManager().addExperience(player, 10);
+          new MessageBuilder("IN_GAME_MESSAGES_LOBBY_GAME_START").asKey().arena(arena).player(player).sendPlayer();
+          plugin.getSpecialItemManager().addSpecialItemsOfStage(player, SpecialItem.DisplayStage.IN_GAME);
+          plugin.getRewardsHandler().performReward(player, arena, plugin.getRewardsHandler().getRewardType("START_GAME"));
+          plugin.getUserManager().addStat(user, plugin.getStatsStorage().getStatisticType("GAMES_PLAYED"));
+        });
       }
       arenaTimer = plugin.getConfig().getInt("Time-Manager.In-Game", 270);
     }

--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/events/spectator/SpectatorEvents.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/events/spectator/SpectatorEvents.java
@@ -154,8 +154,7 @@ public class SpectatorEvents implements Listener {
       return;
     }
     if(player.getLocation().getY() < VersionUtils.getWorldMinHeight(player.getWorld())) {
-      VersionUtils.teleport(player, arena.getStartLocation());
-      event.setDamage(0);
+      VersionUtils.teleport(player, arena.getStartLocation()).thenAccept(bol -> event.setDamage(0));
     }
     event.setCancelled(true);
   }

--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/utils/version/VersionUtils.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/utils/version/VersionUtils.java
@@ -63,6 +63,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -171,20 +172,19 @@ public final class VersionUtils {
 
   private static JavaPlugin plugin;
 
-  public static void teleport(Entity entity, Location location) {
+  public static CompletableFuture<Boolean> teleport(Entity entity, Location location) {
     if(isPaper) {
       // Avoid Future.get() method to be called from the main thread
 
       if(Bukkit.isPrimaryThread()) { // Checks if the current thread is not async
-        PaperLib.teleportAsync(entity, location);
-        return;
+        return PaperLib.teleportAsync(entity, location);
       }
 
       if(plugin == null)
         plugin = JavaPlugin.getPlugin(PluginMain.class);
 
       try {
-        Bukkit.getScheduler().callSyncMethod(plugin, () -> PaperLib.teleportAsync(entity, location)).get();
+        return Bukkit.getScheduler().callSyncMethod(plugin, () -> PaperLib.teleportAsync(entity, location)).get();
       } catch(InterruptedException | ExecutionException e) {
         e.printStackTrace();
       } catch(CancellationException e) {
@@ -193,6 +193,8 @@ public final class VersionUtils {
     } else {
       entity.teleport(location);
     }
+
+    return new CompletableFuture<>();
   }
 
   public static void sendParticles(String particleName, Player player, Location location, int count) {


### PR DESCRIPTION
Original #18 

The discussion on this issue is still ongoing. This fix was initiated by me, so what I opened a PR for and seems likely to be acceptable, I'm still maintaining. What was mentioned in the previous PR, I can't say more. I still use this implementation in my own plugins, as it fixes the disappearance of items when switching between multiple worlds. I don't think there should be any further changes in this PR. This is correct as it is done now, but if there is something you can fork and change, or even me.

Discord thread discussion: https://discord.com/channels/345628548716822530/1058176621045092402

I am mentioning @Waterman1001 since he wants this "fix"

Edit: For extra proof of fixing this: worlds' chunk loading has changed a lot, which means that these chunk loadings run on a separate thread so that they don't affect the player's client (so no lag when you want to teleport from another world). This chunk loading applies to teleportation in the same way, no matter how far away or to another world the player wants to teleport, those chunks must be loaded, because after a while they will be removed (using less memory), so that if there is no living player in the nearby. However, if a player were to appear, as I said, that chunk must be loaded within a specified area, because if it were not, the player would fall into the void and there would be nothing nearby.