### PR TITLE
Allow Placeholders to be used from a Global Context

### DIFF
--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/api/StatsStorage.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/api/StatsStorage.java
@@ -55,7 +55,7 @@ public class StatsStorage {
     if(statisticType.isPersistent()) {
       plugin.getUserManager().getDatabase().addColumn(statisticType.getName(), statisticType.getDatabaseParameters());
     }
-    plugin.getPlaceholderManager().registerPlaceholder(new Placeholder("user_statistic_" + statisticType.getName(), Placeholder.PlaceholderExecutor.ALL) {
+    plugin.getPlaceholderManager().registerPlaceholder(new Placeholder("user_statistic_" + statisticType.getName(), Placeholder.PlaceholderExecutor.ALL, true) {
       @Override
       public String getValue(Player player) {
         return Integer.toString(getUserStats(player, statisticType));

--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/arena/options/ArenaOptionManager.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/arena/options/ArenaOptionManager.java
@@ -68,7 +68,7 @@ public class ArenaOptionManager {
   }
 
   private void loadExternals(String key) {
-    plugin.getPlaceholderManager().registerPlaceholder(new Placeholder("option_" + key.toLowerCase(), Placeholder.PlaceholderType.ARENA, Placeholder.PlaceholderExecutor.ALL) {
+    plugin.getPlaceholderManager().registerPlaceholder(new Placeholder("option_" + key.toLowerCase(), Placeholder.PlaceholderType.ARENA, Placeholder.PlaceholderExecutor.ALL, false) {
       @Override
       public String getValue(Player player, PluginArena arena) {
         return String.valueOf(arena.getArenaOption(key));

--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/handlers/placeholder/PAPIPlaceholders.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/handlers/placeholder/PAPIPlaceholders.java
@@ -60,14 +60,14 @@ public class PAPIPlaceholders extends PlaceholderExpansion {
 
   @Override
   public String onPlaceholderRequest(Player player, @NotNull String id) {
-    if(player == null) {
-      return null;
-    }
     for(Placeholder placeholder : plugin.getPlaceholderManager().getRegisteredPAPIPlaceholders()) {
       if(placeholder.getPlaceholderType() == Placeholder.PlaceholderType.ARENA) {
         continue;
       }
       if(id.toLowerCase().equalsIgnoreCase(placeholder.getId())) {
+        if(placeholder.requiresPlayer() && player == null) {
+          return null;
+        }
         return placeholder.getValue(player);
       }
     }
@@ -85,6 +85,9 @@ public class PAPIPlaceholders extends PlaceholderExpansion {
       }
 
       if(data[1].toLowerCase().equalsIgnoreCase(placeholder.getId())) {
+        if(placeholder.requiresPlayer() && player == null) {
+          return null;
+        }
         return placeholder.getValue(player, arena);
       }
     }

--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/handlers/placeholder/Placeholder.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/handlers/placeholder/Placeholder.java
@@ -32,15 +32,18 @@ public class Placeholder {
   private final String id;
   private final PlaceholderType placeholderType;
   private final PlaceholderExecutor placeholderExecutor;
+  private final Boolean requiresPlayer;
 
-  public Placeholder(String id, PlaceholderExecutor placeholderExecutor) {
+  public Placeholder(String id, PlaceholderExecutor placeholderExecutor, Boolean requiresPlayer) {
     this.id = id;
+    this.requiresPlayer = requiresPlayer;
     this.placeholderType = PlaceholderType.GLOBAL;
     this.placeholderExecutor = placeholderExecutor;
   }
 
-  public Placeholder(String id, PlaceholderType placeholderType, PlaceholderExecutor placeholderExecutor) {
+  public Placeholder(String id, PlaceholderType placeholderType, PlaceholderExecutor placeholderExecutor, Boolean requiresPlayer) {
     this.id = id;
+    this.requiresPlayer = requiresPlayer;
     this.placeholderType = placeholderType;
     this.placeholderExecutor = placeholderExecutor;
   }
@@ -77,6 +80,10 @@ public class Placeholder {
   public String getValue(PluginArena arena) {
     // EMPTY
     return null;
+  }
+
+  public Boolean requiresPlayer() {
+    return requiresPlayer;
   }
 
 

--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/handlers/placeholder/PlaceholderManager.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/handlers/placeholder/PlaceholderManager.java
@@ -49,7 +49,7 @@ public class PlaceholderManager {
   }
 
   private void insertDefaultPlaceholders() {
-    registerPlaceholder(new Placeholder("arena_players_online", Placeholder.PlaceholderExecutor.ALL) {
+    registerPlaceholder(new Placeholder("arena_players_online", Placeholder.PlaceholderExecutor.ALL, false) {
       @Override
       public String getValue(Player player) {
         return Integer.toString(plugin.getArenaRegistry().getArenaPlayersOnline());
@@ -65,7 +65,7 @@ public class PlaceholderManager {
         return Integer.toString(plugin.getArenaRegistry().getArenaPlayersOnline());
       }
     });
-    registerPlaceholder(new Placeholder("players", Placeholder.PlaceholderType.ARENA, Placeholder.PlaceholderExecutor.PLACEHOLDER_API) {
+    registerPlaceholder(new Placeholder("players", Placeholder.PlaceholderType.ARENA, Placeholder.PlaceholderExecutor.PLACEHOLDER_API, false) {
       @Override
       public String getValue(Player player, PluginArena arena) {
         return Integer.toString(arena.getPlayers().size());
@@ -77,7 +77,7 @@ public class PlaceholderManager {
       }
     });
     //dup of arena_option_max_players
-    registerPlaceholder(new Placeholder("max_players", Placeholder.PlaceholderType.ARENA, Placeholder.PlaceholderExecutor.PLACEHOLDER_API) {
+    registerPlaceholder(new Placeholder("max_players", Placeholder.PlaceholderType.ARENA, Placeholder.PlaceholderExecutor.PLACEHOLDER_API, false) {
       @Override
       public String getValue(Player player, PluginArena arena) {
         return Integer.toString(arena.getMaximumPlayers());
@@ -88,7 +88,7 @@ public class PlaceholderManager {
         return Integer.toString(arena.getMaximumPlayers());
       }
     });
-    registerPlaceholder(new Placeholder("state", Placeholder.PlaceholderType.ARENA, Placeholder.PlaceholderExecutor.PLACEHOLDER_API) {
+    registerPlaceholder(new Placeholder("state", Placeholder.PlaceholderType.ARENA, Placeholder.PlaceholderExecutor.PLACEHOLDER_API, false) {
       @Override
       public String getValue(Player player, PluginArena arena) {
         return arena.getArenaState().toString().toLowerCase();
@@ -99,7 +99,7 @@ public class PlaceholderManager {
         return arena.getArenaState().toString().toLowerCase();
       }
     });
-    registerPlaceholder(new Placeholder("state_pretty", Placeholder.PlaceholderType.ARENA, Placeholder.PlaceholderExecutor.PLACEHOLDER_API) {
+    registerPlaceholder(new Placeholder("state_pretty", Placeholder.PlaceholderType.ARENA, Placeholder.PlaceholderExecutor.PLACEHOLDER_API, false) {
       @Override
       public String getValue(Player player, PluginArena arena) {
         return arena.getArenaState().getPlaceholder();
@@ -110,7 +110,7 @@ public class PlaceholderManager {
         return arena.getArenaState().getPlaceholder();
       }
     });
-    registerPlaceholder(new Placeholder("name", Placeholder.PlaceholderType.ARENA, Placeholder.PlaceholderExecutor.PLACEHOLDER_API) {
+    registerPlaceholder(new Placeholder("name", Placeholder.PlaceholderType.ARENA, Placeholder.PlaceholderExecutor.PLACEHOLDER_API, false) {
       @Override
       public String getValue(Player player, PluginArena arena) {
         return arena.getMapName();
@@ -121,7 +121,7 @@ public class PlaceholderManager {
         return arena.getMapName();
       }
     });
-    registerPlaceholder(new Placeholder("timer", Placeholder.PlaceholderType.ARENA, Placeholder.PlaceholderExecutor.PLACEHOLDER_API) {
+    registerPlaceholder(new Placeholder("timer", Placeholder.PlaceholderType.ARENA, Placeholder.PlaceholderExecutor.PLACEHOLDER_API, false) {
       @Override
       public String getValue(Player player, PluginArena arena) {
         return Integer.toString(arena.getTimer());
@@ -132,7 +132,7 @@ public class PlaceholderManager {
         return Integer.toString(arena.getTimer());
       }
     });
-    registerPlaceholder(new Placeholder("user_kit", Placeholder.PlaceholderExecutor.ALL) {
+    registerPlaceholder(new Placeholder("user_kit", Placeholder.PlaceholderExecutor.ALL, true) {
       @Override
       public String getValue(Player player) {
         return plugin.getUserManager().getUser(player).getKit().getName();


### PR DESCRIPTION
This PR Allows placeholders to be executed from a global context (where the player object is null), as long as the placeholder has a boolean set to allow being executed from that context. This should allow things like holograms that to parse the player for all players, not just for one player.