### PR TITLE
fix: user saving problem and performance optimize

### DIFF
--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/user/User.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/user/User.java
@@ -46,6 +46,7 @@ public class User {
   private Kit kit;
   private final Map<StatisticType, Integer> stats = new HashMap<>();
   private final Map<String, Double> cooldowns = new HashMap<>();
+  private boolean initialized;
 
   @Deprecated
   public User(Player player) {
@@ -170,4 +171,11 @@ public class User {
     return cooldown <= cooldownCounter ? 0 : cooldown - cooldownCounter;
   }
 
+  public boolean isInitialized() {
+    return initialized;
+  }
+
+  public void setInitialized(boolean initialized) {
+    this.initialized = initialized;
+  }
 }

--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/user/UserManager.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/user/UserManager.java
@@ -129,7 +129,7 @@ public class UserManager {
   }
 
   public void removeUser(User user) {
-    users.remove(user);
+    users.remove(user.getUniqueId());
   }
 
   public UserDatabase getDatabase() {

--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/user/UserManager.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/user/UserManager.java
@@ -29,7 +29,9 @@ import plugily.projects.minigamesbox.classic.user.data.MysqlManager;
 import plugily.projects.minigamesbox.classic.user.data.UserDatabase;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.UUID;
 
 /**
  * @author Tigerpanzer_02
@@ -39,7 +41,7 @@ import java.util.List;
 public class UserManager {
 
   private final UserDatabase database;
-  private final List<User> users = new ArrayList<>();
+  private final HashMap<UUID, User> users = new HashMap<>();
   private final PluginMain plugin;
 
   public UserManager(PluginMain plugin) {
@@ -59,15 +61,13 @@ public class UserManager {
   public User getUser(Player player) {
     java.util.UUID playerId = player.getUniqueId();
 
-    for(User user : users) {
-      if(user.getUniqueId().equals(playerId)) {
-        return user;
-      }
+    if (users.containsKey(playerId)){
+      return users.get(playerId);
     }
 
     plugin.getDebugger().debug("Registering new user {0} ({1})", playerId, player.getName());
     User user = new User(playerId);
-    users.add(user);
+    users.put(playerId, user);
     return user;
   }
 

--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/user/data/MysqlManager.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/user/data/MysqlManager.java
@@ -124,10 +124,14 @@ public class MysqlManager implements UserDatabase {
 
   @Override
   public void saveAllStatistic(User user) {
-    try {
-      Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> database.executeUpdate(getUpdateQuery(user)));
-    } catch(IllegalPluginAccessException ignored) {
-      database.executeUpdate(getUpdateQuery(user));
+    if (!user.isInitialized()){
+      plugin.getDebugger().debug("User been saving while is not is not initialized.");
+    } else {
+      try {
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> database.executeUpdate(getUpdateQuery(user)));
+      } catch (IllegalPluginAccessException ignored) {
+        database.executeUpdate(getUpdateQuery(user));
+      }
     }
   }
 
@@ -145,6 +149,7 @@ public class MysqlManager implements UserDatabase {
         } else {
           createUserStats(user, uuid, statement, playerName);
         }
+        user.setInitialized(true);
       } catch(SQLException exception) {
         throwException(exception);
       }


### PR DESCRIPTION
1. if user join game while sql not executed yet (20tick), then quit immediately will cause all statics reset to default, and saved to database.
 (eg. bungee mode join while server is restarting then will be kicked from server, or join and quit within 20tick)
2. optimize getUser() performance using hashmap

