### PR TITLE
Fix move false not working

### DIFF
--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/handlers/items/SpecialItem.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/handlers/items/SpecialItem.java
@@ -157,7 +157,7 @@ public class SpecialItem {
 
   public void setItem(Player player) {
     if(!move) {
-      new HandlerItem(itemStack).setMovementCancel(true);
+      new HandlerItem(itemStack).setMovementCancel(true).build();
     }
 
     PlayerInventory playerInventory = player.getInventory();


### PR DESCRIPTION
HandlerItem not builded yet, ItemManager will not cancel the clickevent when open a chest.