### PR TITLE
#patch API changes and new version support

### DIFF
--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/handlers/hologram/LeaderboardHologram.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/handlers/hologram/LeaderboardHologram.java
@@ -20,6 +20,7 @@
 package plugily.projects.minigamesbox.classic.handlers.hologram;
 
 import org.apache.commons.lang.StringUtils;
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import plugily.projects.minigamesbox.api.stats.IStatisticType;
 import plugily.projects.minigamesbox.classic.PluginMain;
@@ -90,7 +91,14 @@ public class LeaderboardHologram {
 
   private String getPlayerNameSafely(UUID uuid) {
     String name = plugin.getUserManager().getDatabase().getPlayerName(uuid);
-    return name != null ? name : new MessageBuilder("LEADERBOARD_UNKNOWN_PLAYER").asKey().build();
+    // Attempts to get the bukkit name instead if the name is null from database or an empty string
+    if (name == null || name.isBlank()) {
+      name = Bukkit.getOfflinePlayer(uuid).getName();
+    }
+    if (name == null || name.isBlank()) {
+      return new MessageBuilder("LEADERBOARD_UNKNOWN_PLAYER").asKey().build();
+    }
+    return name;
   }
 
   private Message statisticToMessage() {

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,4 +16,4 @@
 #  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 group=plugily.projects
-version=1.3.8-SNAPSHOT4
+version=1.3.8-SNAPSHOT5


### PR DESCRIPTION
* Major API Revamp for exposing methods that were not exposed previously to external plugins
* Fixed move false not working
* Added support for 1.20.5, 1.20.6, 1.21
* Fixed holograms display

(This is a repeat of the last PR as the version bump failed)