### PR TITLE
#patch Back to stability 2.0

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,3 +1,19 @@
+### (1.3.11-)1.3.15 Release (17.02.2025)
+* Added 1.21.1-4 support
+* Added (3) new ConfigOptions for ArmorStands (BLOCK_IN_GAME_ARMOR_STAND_DESTROY, BLOCK_IN_GAME_ARMOR_STAND_CHECK, BLOCK_IN_GAME_ARMOR_STAND_INTERACT)
+* Fixed arena start time divider did not match from config.yml
+* Fixed spectator can't fly after sneaking out of first person mode
+* Fixed player collissions on spectator mode
+* Fixed sending of leave message for leaving player and the counting in arena
+* Fixed ActionBars did not convert player and arena placeholders by default
+* Fixed compatibility for BannerColoring in 1.20+
+* Fixed sign updates as cached objects got overwrite (#59)
+* Fixed CommandArgument could have multiple permissions while only the first one was checked
+* Changed onDisable process to make sure all data gets saved even on mysql
+* Changed Simplified and fixed getting of custom texture Skulls (1.20+)
+* Changed Simplified and fixed ArenaWallSign on 1.20.5+
+* Changed Attempt to fix incompatibles with other plugins which using scriptengine by rewritting name of own scriptengine [Changed ScriptEngine name to "plugilyprojects"]
+
 ### 1.3.10 Release (09.07.2024)
 * Fixed multiverse teleportation problems on a multiworld server 
 

--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/arena/PluginArenaManager.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/arena/PluginArenaManager.java
@@ -249,6 +249,7 @@ public class PluginArenaManager {
     PluginArenaUtils.resetPlayerAfterGame(arena, player);
     if(!user.isSpectator()) {
       new MessageBuilder(MessageBuilder.ActionType.LEAVE).arena(arena).player(player).sendArena();
+      new MessageBuilder(MessageBuilder.ActionType.LEAVE).arena(arena).player(player).sendPlayer();
     }
     plugin.getSignManager().updateSigns();
     plugin.getDebugger().debug("[{0}] Final leave attempt for {1} took {2}ms", arena.getId(), player.getName(), System.currentTimeMillis() - start);

--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/arena/PluginArenaUtils.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/arena/PluginArenaUtils.java
@@ -111,6 +111,7 @@ public class PluginArenaUtils {
         plugin
                 .getSpecialItemManager()
                 .addSpecialItemsOfStage(player, SpecialItem.DisplayStage.SPECTATOR);
+        VersionUtils.setCollidable(player, false);
       } else {
         player.setAllowFlight(false);
         player.setFlying(false);

--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/arena/states/PluginRestartingState.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/arena/states/PluginRestartingState.java
@@ -61,6 +61,8 @@ public class PluginRestartingState implements ArenaStateHandler {
       arena.getMapRestorerManager().fullyRestoreArena();
       if(plugin.getConfigPreferences().getOption("BUNGEEMODE")) {
         if(ConfigUtils.getConfig(plugin, "bungee").getBoolean("Shutdown-When-Game-Ends")) {
+          // If someone else reports issues on mysql data save, may update to run sync save of allstatistic!
+          // (e.g. the data is now entered correctly in the DB, but only if "Shutdown-When-Game-Ends: false" is set in the bungee.yml, otherwise no data is entered in the database)
           for(Player player : Bukkit.getOnlinePlayers()) {
             IUser user = plugin.getUserManager().getUser(player);
             plugin.getUserManager().saveAllStatistic(user);

--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/arena/states/PluginStartingState.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/arena/states/PluginStartingState.java
@@ -61,7 +61,7 @@ public class PluginStartingState implements ArenaStateHandler {
 
     int timer = arena.getTimer();
 
-    double startWaiting = plugin.getConfig().getDouble("Starting-Waiting-Time", 60);
+    double startWaiting = plugin.getConfig().getDouble("Time-Manager.Waiting", 60);
     arena.getBossbarManager().setProgress(timer / startWaiting);
 
     float exp = (float) (timer / startWaiting);

--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/events/Events.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/events/Events.java
@@ -224,6 +224,9 @@ public class Events implements Listener {
 
   @EventHandler(priority = EventPriority.HIGH)
   public void onArmorStandDestroy(EntityDamageByEntityEvent event) {
+    if(!plugin.getConfigPreferences().getOption("BLOCK_IN_GAME_ARMOR_STAND_DESTROY")) {
+      return;
+    }
     if(!(event.getEntity() instanceof LivingEntity)) {
       return;
     }
@@ -232,10 +235,22 @@ public class Events implements Listener {
       return;
     }
     if(event.getDamager() instanceof Player && plugin.getArenaRegistry().isInArena((Player) event.getDamager())) {
+      if(plugin.getConfigPreferences().getOption("BLOCK_IN_GAME_ARMOR_STAND_CHECK")) {
+        IPluginArena arena = plugin.getArenaRegistry().getArena((Player) event.getDamager());
+        if(arena != null && arena.getArenaState() != IArenaState.IN_GAME) {
+          return;
+        }
+      }
       event.setCancelled(true);
     } else if(event.getDamager() instanceof Projectile) {
       Projectile projectile = (Projectile) event.getDamager();
       if(projectile.getShooter() instanceof Player && plugin.getArenaRegistry().isInArena((Player) projectile.getShooter())) {
+        if(plugin.getConfigPreferences().getOption("BLOCK_IN_GAME_ARMOR_STAND_CHECK")) {
+          IPluginArena arena = plugin.getArenaRegistry().getArena((Player) projectile.getShooter());
+          if(arena != null && arena.getArenaState() != IArenaState.IN_GAME) {
+            return;
+          }
+        }
         event.setCancelled(true);
         return;
       }
@@ -245,9 +260,19 @@ public class Events implements Listener {
 
   @EventHandler(priority = EventPriority.HIGH)
   public void onInteractWithArmorStand(PlayerArmorStandManipulateEvent event) {
-    if(plugin.getArenaRegistry().isInArena(event.getPlayer())) {
-      event.setCancelled(true);
+    if(!plugin.getConfigPreferences().getOption("BLOCK_IN_GAME_ARMOR_STAND_INTERACT")) {
+      return;
     }
+    if(!plugin.getArenaRegistry().isInArena(event.getPlayer())) {
+      return;
+    }
+    if(plugin.getConfigPreferences().getOption("BLOCK_IN_GAME_ARMOR_STAND_CHECK")) {
+      IPluginArena arena = plugin.getArenaRegistry().getArena(event.getPlayer());
+      if(arena != null && arena.getArenaState() != IArenaState.IN_GAME) {
+          return;
+      }
+    }
+    event.setCancelled(true);
   }
 
 

--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/events/spectator/settings/SpectatorSettingsMenu.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/events/spectator/settings/SpectatorSettingsMenu.java
@@ -33,6 +33,7 @@ import org.bukkit.potion.PotionEffectType;
 import plugily.projects.minigamesbox.api.arena.IPluginArena;
 import plugily.projects.minigamesbox.api.user.IUser;
 import plugily.projects.minigamesbox.classic.PluginMain;
+import plugily.projects.minigamesbox.classic.handlers.items.SpecialItem;
 import plugily.projects.minigamesbox.classic.handlers.language.MessageBuilder;
 import plugily.projects.minigamesbox.classic.handlers.reward.Reward;
 import plugily.projects.minigamesbox.classic.handlers.reward.RewardType;
@@ -263,6 +264,9 @@ public class SpectatorSettingsMenu implements Listener {
     firstPersonMode.remove(player);
     player.setSpectatorTarget(null);
     player.setGameMode(GameMode.SURVIVAL);
+    player.setAllowFlight(true);
+    player.setFlying(true);
+    VersionUtils.setCollidable(player, false);
   }
 
   public NormalFastInv getInventory() {

--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/handlers/language/LanguageMigrator.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/handlers/language/LanguageMigrator.java
@@ -44,7 +44,7 @@ import java.util.logging.Level;
 public class LanguageMigrator {
 
   public enum CoreFileVersion {
-    /*ARENA_SELECTOR(0),*/ ARENAS(1), BUNGEE(1), CONFIG(4), KITS(2),
+    /*ARENA_SELECTOR(0),*/ ARENAS(1), BUNGEE(1), CONFIG(5), KITS(2),
     LANGUAGE(2), /*LEADERBOARDS(0),*/ MYSQL(1), PERMISSIONS(1), POWERUPS(1),
     REWARDS(1), /*SIGNS(0),*/ SPECIAL_ITEMS(1), SPECTATOR(1)/*, STATS(0)*/;
 
@@ -164,6 +164,17 @@ public class LanguageMigrator {
             MigratorUtils.removeLineFromFile(file, "  Food: false");
             MigratorUtils.removeLineFromFile(file, "  True: false");
             MigratorUtils.insertAfterLine(file, "Damage:", "  Hunger: false");
+            break;
+          case 4:
+            MigratorUtils.insertAfterLine(file, "    Item-Move: true", "    ArmorStand: \n" +
+                    "        # Should we block armor stand destroy with double click?\n" +
+                    "        Destroy: true\n" +
+                    "        # Should we block armor stand interaction?\n" +
+                    "        Interact: true\n" +
+                    "        # Should these only be blocked while ingame and arena state is in_game? (e.g. Lobby and Ending is blocked)\n" +
+                    "        # Setting it to false means on all stages of the game the event will be cancelled. \n" +
+                    "        # Setting it to true means only while IN_GAME the event will be cancelled.\n" +
+                    "        Check: true\r\n");
             break;
           default:
             break;

--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/preferences/ConfigOption.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/preferences/ConfigOption.java
@@ -45,6 +45,9 @@ public class ConfigOption implements IConfigOption {
     //Commands.Shorter
     options.put("BLOCK_IN_GAME_COMMANDS", new ConfigOption("Block.In-Game.Commands", true, true));
     options.put("BLOCK_IN_GAME_ITEM_MOVE", new ConfigOption("Block.In-Game.Item-Move", true, true));
+    options.put("BLOCK_IN_GAME_ARMOR_STAND_DESTROY", new ConfigOption("Block.In-Game.ArmorStand.Destroy", true, true));
+    options.put("BLOCK_IN_GAME_ARMOR_STAND_INTERACT", new ConfigOption("Block.In-Game.ArmorStand.Interact", true, true));
+    options.put("BLOCK_IN_GAME_ARMOR_STAND_CHECK", new ConfigOption("Block.In-Game.ArmorStand.Check", true, true));
     options.put("DATABASE", new ConfigOption("Database", false, true));
     options.put("REWARDS", new ConfigOption("Rewards", false, true));
     options.put("PLUGIN_CHAT_FORMAT", new ConfigOption("Chat.Format", true, true));

--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/utils/engine/JavaScriptEngine.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/utils/engine/JavaScriptEngine.java
@@ -15,7 +15,8 @@ import java.util.List;
 
 public class JavaScriptEngine {
 
-  private List<String> engineNames = new ArrayList<>(Arrays.asList("js", "JS", "javascript", "JavaScript", "ecmascript", "ECMAScript", "nashorn", "Nashorn"));
+  // private List<String> engineNames = new ArrayList<>(Arrays.asList("js", "JS", "javascript", "JavaScript", "ecmascript", "ECMAScript", "nashorn", "Nashorn"));
+  private List<String> engineNames = new ArrayList<>(Arrays.asList("plugilyprojects"));
   private ScriptEngineManager scriptEngineManager;
   private ScriptEngineFactory scriptEngineFactory;
 

--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/utils/migrator/MigratorUtils.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/utils/migrator/MigratorUtils.java
@@ -53,7 +53,7 @@ public class MigratorUtils {
       Files.write(file.toPath(), updatedLines, StandardCharsets.UTF_8);
     } catch(IOException e) {
       e.printStackTrace();
-      Bukkit.getLogger().warning("[CommonsBox] Something went horribly wrong with migration! Please contact Plugily Projects!");
+      Bukkit.getLogger().warning("[MinigamesBox] Something went horribly wrong with migration! Please contact Plugily Projects!");
     }
   }
 
@@ -94,7 +94,7 @@ public class MigratorUtils {
       fw.close();
     } catch(IOException e) {
       e.printStackTrace();
-      Bukkit.getLogger().warning("[CommonsBox] Something went horribly wrong with migration! Please contact Plugily Projects!");
+      Bukkit.getLogger().warning("[MinigamesBox] Something went horribly wrong with migration! Please contact Plugily Projects!");
     }
   }
 

--- a/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/utils/services/exception/ExceptionLogHandler.java
+++ b/MiniGamesBox Classic/src/main/java/plugily/projects/minigamesbox/classic/utils/services/exception/ExceptionLogHandler.java
@@ -40,8 +40,8 @@ public class ExceptionLogHandler extends Handler {
   public ExceptionLogHandler(PluginMain plugin) {
     this.plugin = plugin;
     Bukkit.getLogger().addHandler(this);
-    addBlacklistedClass("plugily.projects." + plugin.getDescription().getName().toLowerCase() + ".user.data.MysqlManager");
-    addBlacklistedClass("plugily.projects." + plugin.getDescription().getName().toLowerCase() + ".plugily.projects.commonsbox.database.MysqlDatabase");
+    addBlacklistedClass("plugily.projects." + plugin.getDescription().getName().toLowerCase() + ".minigamesbox.classic.user.data.MysqlManager");
+    addBlacklistedClass("plugily.projects." + plugin.getDescription().getName().toLowerCase() + ".minigamesbox.database.MysqlDatabase");
   }
 
   /**

--- a/MiniGamesBox Classic/src/main/resources/config.yml
+++ b/MiniGamesBox Classic/src/main/resources/config.yml
@@ -82,6 +82,15 @@ Block:
     Leave: false
     # Cancels Item Movement into player crafting, enchantment tables, anvils ...
     Item-Move: true
+    ArmorStand:
+        # Should we block armor stand destroy with double click?
+        Destroy: true
+        # Should we block armor stand interaction?
+        Interact: true
+        # Should these only be blocked while ingame and arena state is in_game? (e.g. Lobby and Ending is blocked)
+        # Setting it to false means on all stages of the game the event will be cancelled.
+        # Setting it to true means only while IN_GAME the event will be cancelled.
+        Check: true
 
 
 # Enable this option when you're using MySQL, otherwise it won't work.
@@ -197,4 +206,4 @@ Update-Notifier:
 # You edited it, huh? Next time hurt yourself!
 Do-Not-Edit:
   File-Version: 1
-  Core-Version: 4
+  Core-Version: 5

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,4 +16,4 @@
 #  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 group=plugily.projects
-version=1.3.15-SNAPSHOT0
+version=1.3.15-SNAPSHOT1

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,4 +16,4 @@
 #  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 group=plugily.projects
-version=1.3.15-SNAPSHOT4
+version=1.3.15-SNAPSHOT5

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,4 +16,4 @@
 #  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 group=plugily.projects
-version=1.3.15-SNAPSHOT2
+version=1.3.15-SNAPSHOT3

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,4 +16,4 @@
 #  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 group=plugily.projects
-version=1.3.15
+version=1.3.15-SNAPSHOT0

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,4 +16,4 @@
 #  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 group=plugily.projects
-version=1.3.15-SNAPSHOT1
+version=1.3.15-SNAPSHOT2

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,4 +16,4 @@
 #  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 group=plugily.projects
-version=1.3.15-SNAPSHOT3
+version=1.3.15-SNAPSHOT4


### PR DESCRIPTION
* Added 1.21.1-4 support
* Added (3) new ConfigOptions for ArmorStands (BLOCK_IN_GAME_ARMOR_STAND_DESTROY, BLOCK_IN_GAME_ARMOR_STAND_CHECK, BLOCK_IN_GAME_ARMOR_STAND_INTERACT)
* Fixed arena start time divider did not match from config.yml
* Fixed spectator can't fly after sneaking out of first person mode
* Fixed player collissions on spectator mode
* Fixed sending of leave message for leaving player and the counting in arena
* Fixed ActionBars did not convert player and arena placeholders by default
* Fixed compatibility for BannerColoring in 1.20+
* Fixed sign updates as cached objects got overwrite (#59)
* Fixed CommandArgument could have multiple permissions while only the first one was checked
* Changed onDisable process to make sure all data gets saved even on mysql
* Changed Simplified and fixed getting of custom texture Skulls (1.20+)
* Changed Simplified and fixed ArenaWallSign on 1.20.5+
* Changed Attempt to fix incompatibles with other plugins which using scriptengine by rewritting name of own scriptengine [Changed ScriptEngine name to "plugilyprojects"]
