### PR TITLE
align holiday config key with code implementation

### DIFF
--- a/MiniGamesBox Classic/src/main/resources/config.yml
+++ b/MiniGamesBox Classic/src/main/resources/config.yml
@@ -144,7 +144,7 @@ Sign-Block-States: true
 # Eg. 4 days before and 4 days after Halloween special effects
 # for death, spooky! There are more holiday events! Check wiki!
 # Wiki: -
-Holidays: true
+Holidays-Enabled: true
 
 
 # Should the plugin enable special powerups which can be found in powerups.yml


### PR DESCRIPTION
Hello! 👋

While using this great plugin, I noticed that the holiday events weren't triggering because of a small mismatch in the config key name.

The Issue: The code looks for Holidays-Enabled, but the config template used Holidays.

The Fix: I've updated the template to match the code.

Thank you for all the hard work on this project! Let me know if this looks good to you. 😊

![68cbe22c-272f-4d34-b7db-4a0aa5b2a41f](https://github.com/user-attachments/assets/2204b85d-dadd-4e4e-95e8-0f622167e4ea)
<img width="429" height="139" alt="image" src="https://github.com/user-attachments/assets/4973138b-ac49-456c-bb7f-42a12b44940d" />
